### PR TITLE
feat: Add smithery.yaml for correct deployment configuration

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,23 @@
+runtime: "container"
+build:
+  dockerfile: "Dockerfile"
+  dockerBuildPath: "."
+startCommand:
+  type: "http"
+  configSchema:
+    type: "object"
+    required: ["MAPBOX_ACCESS_TOKEN"]
+    properties:
+      MAPBOX_ACCESS_TOKEN:
+        type: "string"
+        title: "Mapbox access_token"
+        description: "Your Mapbox secret access token"
+        sensitive: true
+  commandFunction: |
+    (config) => ({
+      command: 'node',
+      args: ['dist/index.js'],
+      env: {
+        MAPBOX_ACCESS_TOKEN: config.MAPBOX_ACCESS_TOKEN
+      }
+    })


### PR DESCRIPTION
Added the smithery.yaml file to align with the existing manifest.json. Testing to see if this change allows us to deploy the server to smithery.yaml. 